### PR TITLE
GAL-24_restricao_campo_matriz_curricular_somente_numeros_ou_vazio

### DIFF
--- a/aplicacoes/gal_npi/src/main/java/br/ufc/npi/gal/model/EstruturaCurricular.java
+++ b/aplicacoes/gal_npi/src/main/java/br/ufc/npi/gal/model/EstruturaCurricular.java
@@ -45,6 +45,8 @@ public class EstruturaCurricular{
 	private List<IntegracaoCurricular> curriculos;
 
 	@Column(name = "matriz_curricular")
+	@NotEmpty(message="Campo Obrigatório")
+	@Pattern.List({@Pattern(regexp="(?!^\\d+$)^.+$", message="O campo não pode conter apenas números")})
 	private String matrizCurricular;
 
 	@Column(name = "unidade_vinculacao")


### PR DESCRIPTION
O campo matriz curricular em editar estrutura curricular agora não aceita somente números nem o campo vazio.